### PR TITLE
test: fix tracks page tests

### DIFF
--- a/src/pages/tracks.js
+++ b/src/pages/tracks.js
@@ -3,8 +3,8 @@ import { useQuery, gql } from '@apollo/client';
 import TrackCard from '../containers/track-card';
 import { Layout, QueryResult } from '../components';
 
-/** TRACKS gql query to retreive all tracks */
-const TRACKS = gql`
+/** TRACKS gql query to retrieve all tracks */
+export const TRACKS = gql`
   query getTracks {
     tracksForHome {
       id


### PR DESCRIPTION
Fixes tracks page tests.

#### Description

`src/pages/__tests__/tracks.js` imports both the `Tracks` component and the `TRACKS` query document.

```javascript
...
import Tracks, { TRACKS } from '../tracks';
...
```